### PR TITLE
feat: add memory system for chat context persistence

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config'
 import { runLLM } from './src/llm'
+import { addMessages, getMessages } from './src/memory'
 
 const userMessage = process.argv[2]
 
@@ -8,6 +9,11 @@ if (!userMessage) {
   process.exit(1)
 }
 
-const reponse = await runLLM({ userMessage })
+await addMessages([{ role: 'user', content: userMessage }])
+
+const messages = await getMessages()
+const reponse = await runLLM({ messages })
 
 console.log(reponse)
+
+await addMessages([{ role: 'assistant', content: reponse }])

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1,17 +1,13 @@
 import { openai } from './ai'
+import type { AIMessage } from '../types'
 
 export const runLLM = async ({
-  userMessage,
-}: { userMessage: string }) => {
+  messages,
+}: { messages: AIMessage[] }) => {
   const response = await openai.chat.completions.create({
     model: 'gpt-4o-mini',
     temperature: 0.1,
-    messages: [
-      {
-        role: 'user',
-        content: userMessage,
-      }
-    ]
+    messages,
   })
 
   return response.choices[0].message.content

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,0 +1,45 @@
+import { JSONFilePreset } from 'lowdb/node'
+import type { AIMessage } from '../types'
+import { v4 as uuidv4 } from 'uuid'
+
+export type MessageWithMetadata = AIMessage & {
+  id: string,
+  createdAt: string,
+}
+
+type Data = {
+  messages: MessageWithMetadata[]
+}
+
+export const addMetadata = (message: AIMessage): MessageWithMetadata => {
+  return {
+    ...message,
+    id: uuidv4(),
+    createdAt: new Date().toISOString(),
+  }
+}
+
+export const removeMetadata = (message: MessageWithMetadata) => {
+  const { id, createdAt, ...rest } = message
+  return rest
+}
+
+const defaultData: Data = {
+  messages: [],
+}
+
+export const getDb = async () => {
+  const db = await JSONFilePreset('db.json', defaultData)
+  return db
+}
+
+export const addMessages = async (messages: AIMessage[]) => {
+  const db = await getDb();
+  db.data.messages.push(...messages.map(addMetadata))
+  await db.write()
+}
+
+export const getMessages = async () => {
+  const db = await getDb();
+  return db.data.messages.map(removeMetadata);
+}


### PR DESCRIPTION
## Add Memory System for Chat Context Persistence

**Issue:** The current approach takes in every user prompt without considering previous messages as the conversation is not kept. The system does not remember previous conversation exchanges and, as such, profoundly fails to respond to a prompt such as “What is my name?" after a user introduces themselves as “Hi, my name is Eric" in a different session colloquially.

**Solution:** To enable the system bridging multiple API calls, a conversation history system is integrated using LowDB and a JSON file. The AIMessage type is augmented with additional metadata such as id and createdAt timestamps as message storage and retrieval functions are designed. The type MessageWithMetadata unifies AIMessage with id and createdAt fields for persistence in the system. Messages along with metadata such as timestamps are stored in an array in the root project file db.json. This means the LLM has the entire context of the conversation across multiple exchanges and can carry forward the information the user provides to sustain coherent multi-turn dialogues.

**Implementation Details:** Two tasks are implemented in this commit. The first is index.ts. It is augmented with memory operations around LLM calls. The second is src/llm.ts where the class is modified to accept arrays of messages instead of a single user message. The last piece is the newly created src/memory.ts where the actual memory management code resides. The memory system is augmented with persistence using LowDB's JSONFilePreset, UUID v4 for message ID, and ISO timestamp for ordering. The system is augmented with features to automatically capture and store user messages, and system responses, to enable the full conversation history to be retained. The messages are stripped of any user meta data for LLM consumption, but are stored with meta data in the system.

**Example Usage:**
```bash
npm start "hi, my name is EtherWizard22"
npm start "hi, is my name?"
```

The second call will now remember the name provided in the first call, demonstrating the memory functionality.